### PR TITLE
Aperfeiçoando o README e o ficheiro em SHell Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Identify Missing Icons
 
-This script check your installed applications and scans an icon pack folder for missing icons. With data found in the `.desktop` files that has the applications information of your system, it generates a my_request.txt file that contains all the icons that are missing from an Icon Pack.
+This script checks your installed applications and scans an icon pack folder for missing icons. With data found in the `.desktop` files that has the applications information of your system, it generates a `my_request.txt` file that contains all the icons that are missed from an icon pack.
+
+## Requirements
+
+* `git`
+* `vala`
+* `wget`
 
 ## How to use:
 
@@ -16,8 +22,7 @@ To get some icons link that I added, use the program:
 ./Main
 ```
 
-
-A **my_request** file is generated in this folder so you can create a request in the icon pack repository. You must edit this file and place the links to the application icons in line `[Icon Link]()`
+A **my_request** file is generated in this folder, so you can create a request in the icon pack repository. You must edit this file and place the links to the application icons in line `[Icon Link]()`.
 
 Example:
 
@@ -30,9 +35,7 @@ Icon=com.github.mdh34.quickdocs
 
 ## Passing optional language
 
-If you need a language other than English use the `--lang` parameter and pass your language code
-
-Example:
+If you need an icon pack's author's native language other than English, use the `--lang` parameter and pass your language code. Example:
 
 The Italian language code is `it`.
 
@@ -42,8 +45,7 @@ The Italian language code is `it`.
 
 Note that only the applications that have in the `.desktop` file data for the chosen language will have translation.
 
-
-`.desktop` files are usually stored in the following folders:
+The `.desktop` files are usually stored in the following folders:
 
 ```
 /usr/share/applications
@@ -51,6 +53,7 @@ Note that only the applications that have in the `.desktop` file data for the ch
 ~/.local/share/flaptak/app
 /var/lib/snapd/desktop/applications/
 ```
+
 ## Build
 
 ```

--- a/identify-missing-icons.sh
+++ b/identify-missing-icons.sh
@@ -1,5 +1,69 @@
 #!/bin/bash
 
+case "$LANG" in
+    de_*)
+        msg_icon_path="Gib den Pfad des Icons-Themas:"
+				msg_analysing="Zum analysieren"
+				msg_generated="Deine nachgesuchte Datei wurde korrekt generiert!"
+				msg_fail="FEHLER: Der gegebene Pfad existiert nicht."
+				msg_double_click="Bitte überprüfe neu den korrekten Pfad des Icons-Themas."
+        ;;
+    es_*)
+        msg_icon_path="Escriba la ruta del tema de iconos:"
+				msg_analysing="Analizando"
+				msg_generated="¡Su archivo solicitado se generó correctamente!"
+				msg_fail="ERROR: La ruta que usted escribió no existe."
+				msg_double_click="POr favor verifique nuevamente la ruta correcta del tema de iconos."
+        ;;
+    fr_*)
+        msg_icon_path="Écrivez le chemin du thème d’icônes:"
+				msg_analysing="En cours d’analyse"
+				msg_generated="Votre fichier demandé a été généré correctement !"
+				msg_fail="FAUTE : Le chemin que vous avez écrivez n’existe pas."
+				msg_double_click="S’il vous plaît, vérifiez nouvellement le chemin correct du thème d’icônes."
+        ;;
+    it_*)
+        msg_icon_path="Scrive il percorso del pacchetto di icone:"
+				msg_analysing="Analizzando"
+				msg_generated="Il tuo file richiesto è stato generato correttamente!"
+				msg_fail="ERRORE: Il percorso che hai scritto non esiste."
+				msg_double_click="Per favore ricontrolla il percorso corretto del pacchetto di icone."
+        ;;
+    nl_*)
+        msg_icon_path="Scrijft het pad van het pictogrammenthema:"
+				msg_analysing="Analyseren"
+				msg_generated="Uw aangevraagde bestand is correct gegenereerd!"
+				msg_fail="FOUTJE: Het pad dat u hebt geschreven bestaat niet."
+				msg_double_click="Alstublieft controleer weer het juiste pad van het pictogrammenthema."
+        ;;
+    pt_BR*)
+        msg_icon_path="Digite o camainho do pacote de ícones:"
+				msg_analysing="Analisando"
+				msg_generated="Seu arquivo solicitado foi gerado corretamente!"
+				msg_fail="ERRO: O caminho digitado não existe."
+				msg_double_click="Por favor, verifique novamente o caminho correto do pacote de ícones."
+        ;;
+    pt_PT*)
+        msg_icon_path="Introduz o camainho do tema de ícones:"
+				msg_analysing="Analisando"
+				msg_generated="Seu ficheiro solicitado foi gerado correctamente!"
+				msg_fail="FALHA: O caminho introduzido não existe."
+				msg_double_click="Por favor, volte a verificar o caminho correcto do pacote de ícones."
+        ;;
+    *)
+        # English as default
+        msg_icon_path="Type icon pack path:"
+				msg_analysing="Analysing"
+				msg_generated="Your request file was generated correctly!"
+				msg_fail="ERROR: The path you typed don't exist."
+				msg_double_click="Please double-check the correct icon pack path."
+        ;;
+esac
+
+_msg() {
+    echo "=>" "$@" >&2
+}
+
 # Set default language english
 lang=${lang:-en}
 
@@ -24,7 +88,7 @@ desktop_icons=(
 suffix=".desktop"
 dest_file="my_request.txt"
 
-read -p "Type icon pack path: " directory_icons
+read -p "$msg_icon_path " directory_icons
 
 function printAppName() {
 	local appName=$1;
@@ -47,7 +111,7 @@ function printAppName() {
 
 if [ -d $directory_icons ]; then
 	echo ""
-	echo "Analysing ${directory_icons##*/}..."
+	_msg "$msg_analysing ${directory_icons##*/}..."
 	# Check if file already exists and remove them
 	if [ -f $dest_file ]; then
 		rm $dest_file
@@ -97,10 +161,10 @@ if [ -d $directory_icons ]; then
 		fi
 	done
 	echo ""
-	echo "Your request file was generated correctly!"
+	_msg "$msg_generated"
 	
 	else
 		echo ""
-		echo "ERROR: The path you typed don't exist."
-		echo "Please double-check the correct icon pack path."
+		_msg "$msg_fail"
+		_msg "$msg_double_click"
 fi


### PR DESCRIPTION
* Ficheiro `README.md`
  * Corrigi os erros de inglês
  * Melhorei a formatação de texto
  * Tu esqueceste-te de colocar os requerimentos, porque nem todas as distribuições vêm com três pacotes prontos - `git`, `vala` e `wget`

* Ficheiro `identify-missing-icons.sh`:
  * Aderi traduções de 8 idiomas ao ficheiro, para facilitar a compreensão do utilizador. Fiz teste, utilizando o português antes de submeter o *pull request*, e funcionou. O ficheiro com 8 traduções detecta o idioma do sistema operativo e muda-se automaticamente de idioma antes de começar a análise de ícones perdidos. 

## Extra observações

Os teu códigos escritos em Shell Script ainda precisam melhorar, porque vê:

```
LANG=pt_PT ./identify-missing-icons.sh
Introduz o camainho do tema de ícones /home/gusbemacbe/.local/share/icons/Adwaita++-Dark 

=> Analisando Adwaita++-Dark...
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
find: warning: ‘-name’ matches against basenames only, but the given pattern contains a directory separator (‘/’), thus the expression will evaluate to false all the time.  Did you mean ‘-wholename’?
sed: can't read /home/gusbemacbe/.local/share/applications/userapp-Firefox: No such file or directory
sed: can't read Developer: No such file or directory
sed: can't read Edition-217FA0.desktop: No such file or directory
grep: /home/gusbemacbe/.local/share/applications/userapp-Firefox: No such file or directory
grep: Developer: No such file or directory
grep: Edition-217FA0.desktop: No such file or directory

=> Seu ficheiro solicitado foi gerado correctamente!
```

Podes ver que os ficheiros `.desktop`, como principalmente `userapp-Firefox Developer Edition-217FA0.desktop`, têm um espaço, por isto, o ficheiro falhou em lê-lo. 
